### PR TITLE
v0.1.3-alpha - Fix some bad luck

### DIFF
--- a/AG.EnumLocalization/EnumLoc.cs
+++ b/AG.EnumLocalization/EnumLoc.cs
@@ -15,8 +15,12 @@ namespace AG.EnumLocalization
         /// <param name="langCode">Language code.</param>
         /// <param name="assembly"><see cref="Assembly"/>.</param>
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.PreserveSig)]
-        public static void SetDefaultLanguage(string langCode, Assembly? assembly = null)
-            => EnumLocEngine.DefaultLanguages[assembly ?? Assembly.GetCallingAssembly()] = langCode;
+        public static void SetDefaultLanguage(string? langCode, Assembly? assembly = null)
+        {
+            assembly ??= Assembly.GetCallingAssembly();
+            if (langCode is null) EnumLocEngine.DefaultLanguages.TryRemove(assembly, out _);
+            else EnumLocEngine.DefaultLanguages[assembly] = langCode;
+        }
 
         /// <summary>Gets the default language code for a specific <paramref name="assembly"/>.</summary>
         /// <param name="assembly"><see cref="Assembly"/>.</param>

--- a/AG.EnumLocalization/Internal/EnumLocEngine.cs
+++ b/AG.EnumLocalization/Internal/EnumLocEngine.cs
@@ -21,7 +21,7 @@ namespace AG.EnumLocalization.Internal
             if (s_strings.TryGetValue(assembly, out var keys) && keys.TryGetValue(key, out var langs))
             {
                 if (langCode is not null && langs.TryGetValue(langCode, out var result)) return result;
-                if (DefaultLanguages.TryGetValue(assembly, out var defaultLangCode) && defaultLangCode is not null && defaultLangCode != langCode && langs.TryGetValue(defaultLangCode, out result)) return result;
+                if (DefaultLanguages.TryGetValue(assembly, out var defaultLangCode) && defaultLangCode != langCode && langs.TryGetValue(defaultLangCode, out result)) return result;
             }
             return GetFallback(assembly, key);
         }

--- a/AG.EnumLocalization/Internal/EnumLocEngine.cs
+++ b/AG.EnumLocalization/Internal/EnumLocEngine.cs
@@ -21,7 +21,7 @@ namespace AG.EnumLocalization.Internal
             if (s_strings.TryGetValue(assembly, out var keys) && keys.TryGetValue(key, out var langs))
             {
                 if (langCode is not null && langs.TryGetValue(langCode, out var result)) return result;
-                if (DefaultLanguages.TryGetValue(assembly, out var defaultLangCode) && langCode != defaultLangCode && langs.TryGetValue(defaultLangCode, out result)) return result;
+                if (DefaultLanguages.TryGetValue(assembly, out var defaultLangCode) && defaultLangCode is not null && defaultLangCode != langCode && langs.TryGetValue(defaultLangCode, out result)) return result;
             }
             return GetFallback(assembly, key);
         }

--- a/packages.props
+++ b/packages.props
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>0.1.2.0</AssemblyVersion>
+    <AssemblyVersion>0.1.3.0</AssemblyVersion>
 
-    <Version>0.1.2-alpha</Version>
+    <Version>0.1.3-alpha</Version>
     <Authors>Azure Gem</Authors>
 
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
`throw new BadLuckException()`

**Null Default Languages**
No longer cause an exception.

**Fix nullable annotation**
`SetDefaultLanguage`'s `langCode` was meant to be nullable, allowing assembly languages to be set toward fallbacks.